### PR TITLE
fix(docs): update ref for Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ EVM hardhat environment smart contract development project.
 
 Current Implementation of Catalog Shared Creator Contract (cNFT):
 [Catalog.sol](./contracts/catalog/Catalog.sol)
-[Docs](./docs/Catalog.md)
+[Docs](./docs/catalog/Catalog.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ EVM hardhat environment smart contract development project.
 ## Info
 
 Current Implementation of Catalog Shared Creator Contract (cNFT):
-[Catalog.sol](./contracts/catalog/Catalog.sol)
-[Docs](./docs/catalog/Catalog.md)
+
+- [Catalog.sol](./contracts/catalog/Catalog.sol)
+- [Docs](./docs/catalog/Catalog.md)
 
 ---
 


### PR DESCRIPTION
## Description

Closes https://github.com/catalogworks/catalog-contracts/issues/20

This updates the reference to `Docs` to the correct, known URL:

https://github.com/catalogworks/catalog-contracts/blob/main/docs/catalog/Catalog.md

### How to test

- View the rendered [revision](https://github.com/catalogworks/catalog-contracts/blob/888832deadd6b6e5959d80510132fb4f6549dcef/README.md)
- Click `Docs` ✅ 